### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -12,22 +12,22 @@ ThunderKit	KEYWORD1
 # Methods and Functions (KEYWORD2)
 #############################################
 
-begin 				KEYWORD2
-appComamnd			KEYWORD2
+begin	KEYWORD2
+appComamnd	KEYWORD2
 
-joystick			KEYWORD2
-seguidor			KEYWORD2
-enviarSensores		KEYWORD2
+joystick	KEYWORD2
+seguidor	KEYWORD2
+enviarSensores	KEYWORD2
 
-ledAzul				KEYWORD2
-ledVerde            KEYWORD2
-ledArcoIris			KEYWORD2
+ledAzul	KEYWORD2
+ledVerde	KEYWORD2
+ledArcoIris	KEYWORD2
 
-definirLimiar		KEYWORD2
-branco              KEYWORD2
-lerSensor			KEYWORD2
+definirLimiar	KEYWORD2
+branco	KEYWORD2
+lerSensor	KEYWORD2
 
-motores				KEYWORD2
+motores	KEYWORD2
 
-recv_msg			KEYWORD2
-send_msg			KEYWORD2
+recv_msg	KEYWORD2
+send_msg	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords